### PR TITLE
Remove dependency on qpkg_encrypt binary

### DIFF
--- a/QDK_2.x/bin/qbuild
+++ b/QDK_2.x/bin/qbuild
@@ -913,7 +913,10 @@ add_qpkg_tail(){
 # Add encryption.
 add_qpkg_encryption(){
 	verbose_msg "Adding QPKG checksum: $QDK_QPKG_FILE"
-	/usr/bin/qpkg_encrypt $QDK_QPKG_FILE
+	local fs=$(/usr/bin/stat --printf="%s" $QDK_QPKG_FILE)
+	local sig=$(/usr/bin/expr $fs \* 3589 + 1000000000)
+	sig=${sig:0:10}
+	echo $sig | /bin/dd of=$QDK_QPKG_FILE bs=1 seek=$(/usr/bin/expr $fs - 60) count=10 conv=notrunc 2>/dev/null
 }
 
 create_qpkg(){


### PR DESCRIPTION
This change replaces the call to qpkg_encrypt with equivalent shell script.

It will make qbuild independent of the platform constraints introduced by the qpkg_encrypt binary (For example: the packages on ppa:fcwu-tw are 64-bit, even though the userland on a QNAP is 32bit, which sometimes requires two separate 32 & 64 build machines to compile and package an application).