### PR TITLE
fix offline signing

### DIFF
--- a/QDK_2.x/bin/qbuild
+++ b/QDK_2.x/bin/qbuild
@@ -974,7 +974,7 @@ add_qpkg_signature(){
 			verbose_msg "Creating code signing digital signature..."
 			openssl dgst -sha1 -binary "${QDK_QPKG_FILE}" > "${QDK_QPKG_FILE}.sha"
 			openssl cms -sign -in "${QDK_QPKG_FILE}.sha" -binary -nodetach -out "${QDK_QPKG_FILE}.msg" \
-				-signer certificate -inkey private_key 2>/dev/null
+				-signer certificate -inkey private_key -certfile ca_certs 2>/dev/null
 			local err_code=$?
 			if [ $err_code = "2" ]; then
 				warn_msg "Failed to open certificate or private key"


### PR DESCRIPTION
If you use a non-QNAP code signing certificate, the ca_certs of the cert chain will not be used for the actual signing and therefore the validation fails with following error:

```
Adding QPKG checksum: ownCloud_10.8.0.0_x86_64.qpkg
Verification failure
139812787044800:error:2E099064:CMS routines:cms_signerinfo_verify_cert:certificate verify error:../crypto/cms/cms_smime.c:253:Verify error:unable to get local issuer certificate
Code signing digital signature verification failed
```